### PR TITLE
Replace both DOUBLE and INTEGER with NUMBER

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ _Expr_ is deployed to [Maven Central](https://repo1.maven.org/maven2/io/mfj/expr
 * LiteralValue :    Integer | Decimal | String | Regex | Boolean | Date | Time | DateTime
 * String :          '"' TextOrEmpty{" escaped by \} '"'
 * Regex :           '/' TextOrEmpty{/ escaped by \} '/'
-* Decimal :         '-'? Digit+ ( '.' Digit+ )?
-* Integer :         '-'? Digit+
+* Number :          '-'? Digit+ ( '.' Digit+ )?
 * Boolean :         'true' | 'false'
 * Date :            "d'" ISO_8601_Date "'"
 * Time :            "t'" ISO_8601_Time "'"
@@ -40,8 +39,7 @@ It is awesome.
 
 * STRING - `kotlin.String`
 * Regex - `kotlin.text.Regex`
-* Integer - `kotlin.Int`
-* Double - `kotlin.Double`
+* Number - `java.math.BigDecimal`
 * Date - `java.time.LocalDate`
 * Time - `java.time.LocalTime`
 * DateTime - `java.time.LocalDateTime`

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.mfj</groupId>
   <artifactId>expr</artifactId>
-  <version>4.2-SNAPSHOT</version>
+  <version>5.0-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A handy expression parser.</description>

--- a/src/main/java/io/mfj/expr/ExConvert.kt
+++ b/src/main/java/io/mfj/expr/ExConvert.kt
@@ -17,7 +17,6 @@ limitations under the License.
 package io.mfj.expr
 
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.text.SimpleDateFormat
 import java.time.*
 import java.time.format.DateTimeFormatter
@@ -30,8 +29,7 @@ object ExConvert {
       return when (dataType) {
         ExDataType.STRING -> anyToString(v)
         ExDataType.REGEX -> Regex( anyToString(v) ?: throw IllegalArgumentException( "Regex pattern cannot be null" ) )
-        ExDataType.INTEGER -> anyToInt(v)
-        ExDataType.DOUBLE -> anyToDouble(v)
+        ExDataType.NUMBER -> anyToDecimal(v)
         ExDataType.DATE -> anyToLocalDate(v)
         ExDataType.TIME -> anyToLocalTime(v)
         ExDataType.DATETIME -> anyToLocalDateTime(v)
@@ -50,55 +48,11 @@ object ExConvert {
     else -> "$v"
   }
 
-  fun anyToInt(v: Any?) : Any? = when (v) {
+  fun anyToDecimal(v: Any?) : Any? = when (v) {
     null -> null
-    is Int -> v
-    is Long -> v.toInt()
-    is String -> {
-      if (v.isEmpty()) {
-        null
-      } else {
-        BigDecimal(v).setScale(0, RoundingMode.FLOOR).toInt()
-      }
-    }
-    is Float -> v.toInt()
-    is Double -> v.toInt()
-    is BigDecimal -> v.setScale(0, RoundingMode.FLOOR).toInt()
-    else -> "$v".toInt()
-  }
-
-  fun anyToLong(v: Any?) : Any? = when (v) {
-    null -> null
-    is Int -> v.toLong()
-    is Long -> v
-    is String -> {
-      if (v.isEmpty()) {
-        null
-      } else {
-        BigDecimal(v).setScale(0, RoundingMode.FLOOR).toLong()
-      }
-    }
-    is Float -> v.toLong()
-    is Double -> v.toLong()
-    is BigDecimal -> v.setScale(0, RoundingMode.FLOOR).toLong()
-    else -> "$v".toLong()
-  }
-
-  fun anyToDouble(v: Any?) : Any? = when (v) {
-    null -> null
-    is Int -> v.toDouble()
-    is Long -> v.toDouble()
-    is Float -> v.toDouble()
-    is Double -> v
-    is String -> {
-      if (v.isEmpty()) {
-        null
-      } else {
-        v.toDouble()
-      }
-    }
-    is BigDecimal -> v.toDouble()
-    else -> "$v".toDouble()
+    is Number -> v.asBigDecimal()
+    is String -> if ( v.isBlank() ) null else v.toBigDecimal()
+    else -> toString().toBigDecimal()
   }
 
   fun anyToBoolean(v: Any?) : Any? = when (v) {
@@ -163,3 +117,13 @@ object ExConvert {
   }
 
 }
+
+fun Number.asBigDecimal():BigDecimal =
+    when(this) {
+      is BigDecimal -> this
+      is Double -> toBigDecimal()
+      is Float -> toBigDecimal()
+      is Int -> toBigDecimal()
+      is Short -> toInt().toBigDecimal()
+      else -> toString().toBigDecimal()
+    }

--- a/src/main/java/io/mfj/expr/ExDataType.kt
+++ b/src/main/java/io/mfj/expr/ExDataType.kt
@@ -19,8 +19,7 @@ package io.mfj.expr
 enum class ExDataType {
   STRING,
   REGEX,
-  INTEGER,
-  DOUBLE,
+  NUMBER,
   DATE,
   TIME,
   DATETIME,

--- a/src/main/java/io/mfj/expr/ExprLogicStatement.kt
+++ b/src/main/java/io/mfj/expr/ExprLogicStatement.kt
@@ -40,7 +40,7 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
     return when ( op ) {
       ExLogicOpType.EQUAL -> {
         if ( leftVal is Number && rightVal is Number ) {
-          leftVal.toDouble() == rightVal.toDouble()
+          leftVal.asBigDecimal().compareTo( rightVal.asBigDecimal() ) == 0
         } else {
           leftVal == rightVal
         }
@@ -63,7 +63,7 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
             leftVal > rightVal
           }
           leftVal is Number && rightVal is Number -> {
-            leftVal.toDouble() > rightVal.toDouble()
+            leftVal.asBigDecimal() > rightVal.asBigDecimal()
           }
           leftVal is LocalDate && rightVal is LocalDate -> {
             leftVal > rightVal
@@ -88,7 +88,7 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
             leftVal >= rightVal
           }
           leftVal is Number && rightVal is Number -> {
-            leftVal.toDouble() >= rightVal.toDouble()
+            leftVal.asBigDecimal() >= rightVal.asBigDecimal()
           }
           leftVal is LocalDate && rightVal is LocalDate -> {
             leftVal >= rightVal
@@ -113,7 +113,7 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
             leftVal < rightVal
           }
           leftVal is Number && rightVal is Number -> {
-            leftVal.toDouble() < rightVal.toDouble()
+            leftVal.asBigDecimal() < rightVal.asBigDecimal()
           }
           leftVal is LocalDate && rightVal is LocalDate -> {
             leftVal < rightVal
@@ -138,7 +138,7 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
             leftVal <= rightVal
           }
           leftVal is Number && rightVal is Number -> {
-            leftVal.toDouble() <= rightVal.toDouble()
+            leftVal.asBigDecimal() <= rightVal.asBigDecimal()
           }
           leftVal is LocalDate && rightVal is LocalDate -> {
             leftVal <= rightVal

--- a/src/main/java/io/mfj/expr/ExprMathStatement.kt
+++ b/src/main/java/io/mfj/expr/ExprMathStatement.kt
@@ -33,8 +33,8 @@ class ExprMathStatement(val left: ExValue, var op: ExMathOpType, val right:ExVal
   }
 
   private fun calc(leftVal:Number, op:ExMathOpType, rightVal:Number ): Number {
-    val l = leftVal.toDouble()
-    val r = rightVal.toDouble()
+    val l = leftVal.asBigDecimal()
+    val r = rightVal.asBigDecimal()
     return when ( op ) {
       ExMathOpType.PLUS -> l + r
       ExMathOpType.MINUS -> l - r

--- a/src/main/java/io/mfj/expr/ExprPegParser.kt
+++ b/src/main/java/io/mfj/expr/ExprPegParser.kt
@@ -165,7 +165,6 @@ open class ExprPegParser : BaseParser<Any>() {
   open fun LiteralValue() : Rule {
     return FirstOf(
         DecimalValue(),
-        IntegerValue(),
         StringValue(),
         RegexValue(),
         DateTimeValue(),
@@ -179,7 +178,7 @@ open class ExprPegParser : BaseParser<Any>() {
   open fun DecimalValue() : Rule {
     return Sequence(
         Decimal(),
-        push(ExLit(ExDataType.DOUBLE, match()))
+        push(ExLit(ExDataType.NUMBER, match()))
     )
   }
 
@@ -187,24 +186,12 @@ open class ExprPegParser : BaseParser<Any>() {
     return Sequence(
         Optional(CharMatcher('-')),
         OneOrMore(Digit()),
-        Sequence(
-            CharMatcher('.'),
-            OneOrMore(Digit())
+        Optional(
+            Sequence(
+                CharMatcher('.'),
+                OneOrMore(Digit())
+            )
         )
-    )
-  }
-
-  open fun IntegerValue() : Rule {
-    return Sequence(
-        Integer(),
-        push(ExLit(ExDataType.INTEGER, match()))
-    )
-  }
-
-  open fun Integer() : Rule {
-    return Sequence(
-      Optional(CharMatcher('-')),
-      OneOrMore(Digit())
     )
   }
 

--- a/src/test/java/io/mfj/expr/ExprTest.kt
+++ b/src/test/java/io/mfj/expr/ExprTest.kt
@@ -24,14 +24,14 @@ import java.time.LocalDateTime
 class ExprTest {
 
   val model = mapOf(
-      "zero" to ExDataType.INTEGER,
-      "one" to ExDataType.INTEGER,
-      "two" to ExDataType.INTEGER,
-      "aa" to ExDataType.INTEGER,
-      "bb" to ExDataType.INTEGER,
-      "cc" to ExDataType.INTEGER,
-      "dd" to ExDataType.INTEGER,
-      "ddd" to ExDataType.DOUBLE,
+      "zero" to ExDataType.NUMBER,
+      "one" to ExDataType.NUMBER,
+      "two" to ExDataType.NUMBER,
+      "aa" to ExDataType.NUMBER,
+      "bb" to ExDataType.NUMBER,
+      "cc" to ExDataType.NUMBER,
+      "dd" to ExDataType.NUMBER,
+      "ddd" to ExDataType.NUMBER,
       "ss" to ExDataType.STRING,
       "rr" to ExDataType.REGEX,
       "dt" to ExDataType.DATE,
@@ -238,6 +238,18 @@ class ExprTest {
   @Test
   fun test27() = test(
       "1 = ddd",
+      mapOf( "ddd" to 1.0 ),
+      true )
+
+  @Test
+  fun testFloatEq() = test(
+      "1.0 = ddd",
+      mapOf( "ddd" to 1.0f ),
+      true )
+
+  @Test
+  fun testDoubleEq() = test(
+      "1.0 = ddd",
       mapOf( "ddd" to 1.0 ),
       true )
 

--- a/src/test/java/io/mfj/expr/ExprTest.kt
+++ b/src/test/java/io/mfj/expr/ExprTest.kt
@@ -18,6 +18,7 @@ package io.mfj.expr
 
 import org.junit.Assert.*
 import org.junit.Test
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -44,6 +45,14 @@ class ExprTest {
             vp:Map<String,Any?>,
             value:Boolean
             ) {
+    test(exprStr,model,vp,value)
+  }
+
+  fun test( exprStr:String,
+      model:Map<String,ExDataType>,
+      vp:Map<String,Any?>,
+      value:Boolean
+  ) {
     val expr = ExprParser.parseToExpr(exprStr, MapVarTypeProvider(model) )
     val ret = expr.value( MapVarProvider( vp ) )
     assertEquals( value, ret )
@@ -455,4 +464,213 @@ class ExprTest {
   fun testSingleLetterVarName() {
     ExprParser.parse("a < 5")
   }
+
+  @Test
+  fun testCompareDoubleFloat() {
+    test(
+        exprStr = "a = b",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+            "b" to ExDataType.NUMBER
+        ),
+        vp = mapOf(
+            "a" to 3.7,
+            "b" to 3.7f
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareDoubleInt() {
+    test(
+        exprStr = "a = b",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+            "b" to ExDataType.NUMBER
+        ),
+        vp = mapOf(
+            "a" to 3.0,
+            "b" to 3
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareFloatInt() {
+    test(
+        exprStr = "a = b",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+            "b" to ExDataType.NUMBER
+        ),
+        vp = mapOf(
+            "a" to 3.0f,
+            "b" to 3
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareFloatBigDecimal() {
+    test(
+        exprStr = "a = b",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+            "b" to ExDataType.NUMBER
+        ),
+        vp = mapOf(
+            "a" to 3.2f,
+            "b" to BigDecimal("3.2")
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareDoubleBigDecimal() {
+    test(
+        exprStr = "a = b",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+            "b" to ExDataType.NUMBER
+        ),
+        vp = mapOf(
+            "a" to 3.3,
+            "b" to BigDecimal("3.3")
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareIntBigDecimal() {
+    test(
+        exprStr = "a = b",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+            "b" to ExDataType.NUMBER
+        ),
+        vp = mapOf(
+            "a" to 3,
+            "b" to BigDecimal("3.0")
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareDoubleLiteral() {
+    test(
+        exprStr = "a = 3",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to 3.0,
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareFloatLiteral() {
+    test(
+        exprStr = "a = 3",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to 3.0f,
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareIntLiteral() {
+    test(
+        exprStr = "a = 3",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to 3,
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareBigDecimalLiteral() {
+    test(
+        exprStr = "a = 3",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to BigDecimal("3.0")
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareDoubleLiteralDecimal() {
+    test(
+        exprStr = "a = 3.5",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to 3.5,
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareFloatLiteralDecimal() {
+    test(
+        exprStr = "a = 3.9",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to 3.9f,
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareIntLiteralDecimal() {
+    test(
+        exprStr = "a = 3.0",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to 3,
+        ),
+        value = true
+    )
+  }
+
+  @Test
+  fun testCompareBigDecimalLiteralDecimal() {
+    test(
+        exprStr = "a = 3.9",
+        model = mapOf(
+            "a" to ExDataType.NUMBER,
+        ),
+        vp = mapOf(
+            "a" to BigDecimal("3.9")
+        ),
+        value = true
+    )
+  }
+
 }


### PR DESCRIPTION
Nobody using `expr` cares about decimal precision. Combine `ExDataType.INTEGER` and `ExDataType.DOUBLE` to `ExDataType.NUMBER`, which uses `java.math.BigDecimal`. The equals operation (`=`) ignores precision (it uses `compareTo()==0` instead of `.equals()`)

This simplifies `expr` and allows comparisons of integers and doubles, which previously could lead to confusion, especially when using variable providers.

Bumped version to 5.0. Expressions and variable provider values are compatible, but any code using `ExDataType.INTEGER` or `ExDataType.DOUBLE` will no longer work.