### PR TITLE
Allow null literals to use any casing

### DIFF
--- a/src/main/antlr4/Expr.g4
+++ b/src/main/antlr4/Expr.g4
@@ -49,7 +49,8 @@ fragment CONTAINS: '!'?[cC][oO][nN][tT][aA][iI][nN][sS];
 
 literalValue : nul | number | string | bool | regex | date | time | datetime;
 
-nul: 'null';
+nul: NUL;
+NUL: [nN][uU][lL][lL];
 
 string : DQUOTED;
 DQUOTED: '"' (DQUOTED_ESC|.)*? '"';

--- a/src/test/java/io/mfj/expr/ExprTest.kt
+++ b/src/test/java/io/mfj/expr/ExprTest.kt
@@ -277,6 +277,18 @@ class ExprTest {
       true )
 
   @Test
+  fun testNullTitleCase() = test(
+      "ss = Null",
+      mapOf( "ss" to null ),
+      true )
+
+  @Test
+  fun testNullUpperCase() = test(
+      "ss = NULL",
+      mapOf( "ss" to null ),
+      true )
+
+  @Test
   fun test33() = test(
       "ss = null",
       mapOf( "ss" to "a" ),


### PR DESCRIPTION
Story details: https://app.shortcut.com/mfj/story/29088

We have expressions in the Yolo spreadsheet like `Prosecuted=1 AND DysOffnsToClsr=-999 AND DispoDt != Null`. The latest Expr library we pulled in recently did not like these because it was only set up to recognize `null` in lowercase.

In the process of figuring out why this was only erroring during spreadsheet ingestion, and calculations weren't blowing up at runtime, I noticed that we lowercase expressions pretty much universally before we actually use them (see [here](https://github.com/measuresforjustice/portal-server/blob/1d618e599246a94ccc64a84454709484cbfcdc22/realtime-basterquake-server/src/main/java/io/mfj/commons/advancedQuery/calculation/MeasureDimension.kt#L261), [here](https://github.com/measuresforjustice/basterquake/blob/12bb81addea4d85c6125894defd8cc57ede5a9ae/src/main/java/io/mfj/basterquake/cachegen/portal/MeasureDimension.kt#L241) and [here](https://github.com/measuresforjustice/basterquake/blob/12bb81addea4d85c6125894defd8cc57ede5a9ae/src/main/java/io/mfj/basterquake/cachegen/recs/FilterRec.kt#L33-L35))

I could see an argument that we should therefore also lowercase them when validating during SS parsing, but this would be a bigger rework effort as it would involve changing the var type provider casing throughout `SpreadsheetUtil`. 

Given that we're hoping to eliminate Expr soon, and it already supports case-insensitivity in other tokens like `AND` and `OR`, it seemed logical to just restore that prior behavior for null literals as well.