### PR TITLE
fix: [sc-29680] Regression: Incorrect results in expressions with "!=" comparisons for numbers

### DIFF
--- a/src/main/java/io/mfj/expr/ExprLogicStatement.kt
+++ b/src/main/java/io/mfj/expr/ExprLogicStatement.kt
@@ -155,11 +155,7 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
         }
       }
       ExLogicOpType.NOT_EQUAL -> {
-        if ( leftVal is Number && rightVal is Number ) {
-          leftVal.asBigDecimal().compareTo( rightVal.asBigDecimal() ) != 0
-        } else {
-          leftVal != rightVal
-        }
+        !calc(leftVal, ExLogicOpType.EQUAL, rightVal)
       }
       ExLogicOpType.IN -> {
         val rightList = ( rightVal as? List<*> )

--- a/src/main/java/io/mfj/expr/ExprLogicStatement.kt
+++ b/src/main/java/io/mfj/expr/ExprLogicStatement.kt
@@ -154,7 +154,13 @@ class ExprLogicStatement(val left: ExValue, var op: ExLogicOpType, val right:ExV
           }
         }
       }
-      ExLogicOpType.NOT_EQUAL -> { leftVal != rightVal }
+      ExLogicOpType.NOT_EQUAL -> {
+        if ( leftVal is Number && rightVal is Number ) {
+          leftVal.asBigDecimal().compareTo( rightVal.asBigDecimal() ) != 0
+        } else {
+          leftVal != rightVal
+        }
+      }
       ExLogicOpType.IN -> {
         val rightList = ( rightVal as? List<*> )
             ?: throw IllegalArgumentException("right operand for ${ExLogicOpType.IN} must be a list")

--- a/src/test/java/io/mfj/expr/ExprTest.kt
+++ b/src/test/java/io/mfj/expr/ExprTest.kt
@@ -67,6 +67,40 @@ class ExprTest {
   )
 
   @Test
+  fun testNotEqualDistinctNumericLiterals() = test(
+      "2!=1",
+      emptyMap(),
+      emptyMap(),
+      true
+  )
+
+  @Test
+  fun testNotEqualMatchingNumericLiterals() = test(
+      "1<>1",
+      emptyMap(),
+      emptyMap(),
+      false
+  )
+
+  @Test
+  fun testNotEqualDistinctVarAndLiteral() = test(
+      "two<>1",
+      mapOf(
+          "two" to 2
+      ),
+      true
+  )
+
+  @Test
+  fun testNotEqualMatchingVarAndLiteral() = test(
+      "one!=1",
+      mapOf(
+          "one" to 1
+      ),
+      false
+  )
+
+  @Test
   fun test1() = test(
       "NOT(aa=0 AND bb=1 AND cc=2)",
       mapOf(
@@ -253,10 +287,22 @@ class ExprTest {
       true )
 
   @Test
+  fun test26NotEq() = test(
+      "1.0 != aa",
+      mapOf( "aa" to 1 ),
+      false )
+
+  @Test
   fun test27() = test(
       "1 = ddd",
       mapOf( "ddd" to 1.0 ),
       true )
+
+  @Test
+  fun test27NotEq() = test(
+      "1 != ddd",
+      mapOf( "ddd" to 1.0 ),
+      false )
 
   @Test
   fun testFloatEq() = test(
@@ -265,10 +311,22 @@ class ExprTest {
       true )
 
   @Test
+  fun testFloatNotEq() = test(
+      "1.0 <> ddd",
+      mapOf( "ddd" to 1.0f ),
+      false )
+
+  @Test
   fun testDoubleEq() = test(
       "1.0 = ddd",
       mapOf( "ddd" to 1.0 ),
       true )
+
+  @Test
+  fun testDoubleNotEq() = test(
+      "1.0 != ddd",
+      mapOf( "ddd" to 1.0 ),
+      false )
 
   @Test
   fun test28() = test(


### PR DESCRIPTION
Story details: https://app.shortcut.com/mfj/story/29680

- Make the NOT_EQUALS logic correctly mirror the EQUALS logic