### PR TITLE
demonstrate that there's a bug in this version of expr

### DIFF
--- a/src/test/java/io/mfj/expr/ExprTest.kt
+++ b/src/test/java/io/mfj/expr/ExprTest.kt
@@ -443,4 +443,20 @@ class ExprTest {
   fun testSingleLetterVarName() {
     ExprParser.parse("a < 5")
   }
+
+  @Test
+  fun testMixedGroupedConjunctions() = test(
+      "0=1 OR (1=0 AND 1=1)",
+      mapOf(),
+      false
+  )
+
+  @Test
+  fun testMixedUngroupedConjunctions() = test(
+      // "false OR false AND true" should eval to false regardless of AND/OR precedence
+      // FIXME: this fails because this expression parses as (1=1)
+      "0=1 OR 1=0 AND 1=1",
+      mapOf(),
+      false
+  )
 }


### PR DESCRIPTION
This is kind of a weird PR:

This introduces a failing unit test in a branch off of the latest legacy (4.x) tag of `expr` to prove / document that this version of the library has a bug.

Fixing that bug is outside the scope of the ticket (and something we may never do given we are moving to a newer version that doesn't have the bug).

My thought is that we merge this and just keep the `4.x-maintenance` branch around in case we need to patch this older version of expr for some reason -- we'll have a starting point for that with a failing unit test to address as a first order of business