### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # These owners will be the default owners for everything in the repo, unless a
 # later match takes precedence.
-*   @wstumbo-mfj @agreenawaltMFJ
+*   @wstumbo-mfj @agreenawaltMFJ @rbell-mfj
 
 # Make sure that DevOps is aware of anything GitHub related
 /.github/    @wstumbo-mfj @SB-MFJ @meghanbissonnette-mfj

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 *   @wstumbo-mfj @agreenawaltMFJ @rbell-mfj
 
 # Make sure that DevOps is aware of anything GitHub related
-/.github/    @wstumbo-mfj @SB-MFJ @meghanbissonnette-mfj
+/.github/    @wstumbo-mfj @agreenawaltMFJ @rbell-mfj @SB-MFJ @meghanbissonnette-mfj

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # These owners will be the default owners for everything in the repo, unless a
 # later match takes precedence.
-*   @wstumbo-mfj
+*   @wstumbo-mfj @agreenawaltMFJ
 
 # Make sure that DevOps is aware of anything GitHub related
 /.github/    @wstumbo-mfj @SB-MFJ @meghanbissonnette-mfj


### PR DESCRIPTION
I would like to become a codeowner on expr because:
* I'm planning to wrap `expr` into the testing strategy for Commons backend - not necessarily to add tests here, but to include `expr` in whatever code coverage reports or strategy we decide
* I see it has only one codeowner
* I haven't worked in this repo directly, but I did learn a bit about it during the calc engine rewrite